### PR TITLE
Change tabs to spaces to fix indentation

### DIFF
--- a/spi_serial/spi_serial/spi_serial.py
+++ b/spi_serial/spi_serial/spi_serial.py
@@ -53,7 +53,7 @@ class SpiSerial():
             self.rx_buf.append(rx)
         return len(self.rx_buf)
 
-    def reset(self):
-        self.RST = m.Gpio(36)
-        self.RST.dir(m.DIR_OUT)
-        self.RST.write(1)
+    #def reset(self):
+        #self.RST = m.Gpio(36)
+        #self.RST.dir(m.DIR_OUT)
+        #self.RST.write(1)

--- a/spi_serial/spi_serial/spi_serial.py
+++ b/spi_serial/spi_serial/spi_serial.py
@@ -53,7 +53,7 @@ class SpiSerial():
             self.rx_buf.append(rx)
         return len(self.rx_buf)
 
-	def reset(self):
-		self.RST = m.Gpio(36)
+    def reset(self):
+        self.RST = m.Gpio(36)
         self.RST.dir(m.DIR_OUT)
-        self.RST.write(1)	
+        self.RST.write(1)

--- a/spi_serial/spi_serial/spi_serial.py
+++ b/spi_serial/spi_serial/spi_serial.py
@@ -53,7 +53,7 @@ class SpiSerial():
             self.rx_buf.append(rx)
         return len(self.rx_buf)
 
-    #def reset(self):
-        #self.RST = m.Gpio(36)
-        #self.RST.dir(m.DIR_OUT)
-        #self.RST.write(1)
+    def reset(self):
+        self.RST = m.Gpio(36)
+        self.RST.dir(m.DIR_OUT)
+        self.RST.write(1)


### PR DESCRIPTION
With @nick6x pulling the reset out to its own function, and the recent fixes to https://github.com/scottleibrand/mmeowlink/tree/spi, we now have the 915MHzEdisonExplorer board fully working with OpenAPS, and looping reliably after an mmtune.
